### PR TITLE
Use name parameter of the chart to name charts.

### DIFF
--- a/sdk/src/Statechart/CodeGen/SQL.hs
+++ b/sdk/src/Statechart/CodeGen/SQL.hs
@@ -20,7 +20,7 @@ writeSQLs targetPath xs =
 generateSQL :: [(FilePath, ByteString, Chart StateName EventName)] -> [(FilePath, Text)]
 generateSQL =
     fmap $ \(x, _bs, a) ->
-        let code = gen (GenConfig (T.pack (dropExtension x)) (version a)) a
+        let code = gen (GenConfig (T.pack (dropExtension x)) (name a) (version a)) a
          in (x, code)
 
 -------------
@@ -29,14 +29,15 @@ generateSQL =
 
 -- | Configuration for the generation.
 data GenConfig = GenConfig
-    { cfgName :: Text
+    { cfgFile :: Text
+    , cfgName :: Text
     , cfgVersion :: Version
     }
 
 -- | So we can generate SQL from any chart.
 gen :: (AsText e, AsText s, Eq s) => GenConfig -> Chart s e -> Text
 gen GenConfig{..} chart =
-    let h = header cfgName
+    let h = header cfgFile
         s :: Text = stateArea chart
         t :: Text = transitionArea chart
         b = fnBody GenConfig{..} [iii|#{s}\n#{t}|]

--- a/sdk/src/Statechart/Types.hs
+++ b/sdk/src/Statechart/Types.hs
@@ -61,7 +61,8 @@ instance AsText Text where
 
 -- | This is our canonical Chart representation.
 data Chart s e = Chart
-    { version :: Version
+    { name :: Text
+    , version :: Version
     , initial :: s
     , states :: [State s e]
     }


### PR DESCRIPTION
We now search for all scxml files in given directory and generate
corresponding modules and their directories. There is now a
convention that a file in `deploy/statecharts/payment_gateway/swish_flow.scxml` should 
have chart name as `payment_gateway.swish_flow` and the generated sql would be
`payment_gateway/swish_flow.sql`, `PaymentGateway.SwishFlow` as the module name.
`writeHaskells` now also creates any directories needed for the new modules.