### PR TITLE
Less verbose generated Haskell code

### DIFF
--- a/sdk/src/Statechart/CodeGen/Haskell.hs
+++ b/sdk/src/Statechart/CodeGen/Haskell.hs
@@ -147,15 +147,13 @@ stateValueName state = mkName $ "state" <> pascal (T.unpack state)
 eventTypeName :: FlowName -> Text -> Language.Haskell.TH.Name
 eventTypeName flowName = makeEventTypeName . T.unpack
   where
-    eventDataNameText = flowName <> "_events"
     replacePointsForUnderScores = map (\c -> if c == '.' then '_' else c)
-    makeEventTypeName = mkName . (pascal (T.unpack eventDataNameText) <>) . pascal . replacePointsForUnderScores
+    makeEventTypeName = mkName . pascal . replacePointsForUnderScores
 
 stateTypeName :: FlowName -> Text -> Language.Haskell.TH.Name
 stateTypeName flowName = stateToName . T.unpack
   where
-    stateDataNameText = flowName <> "_states"
-    stateToName = mkName . (pascal (T.unpack stateDataNameText) <>) . pascal
+    stateToName = mkName . pascal
 
 ----------------------------------------------------------------------------
 
@@ -173,8 +171,7 @@ genChartStructure flowName Chart{..} = do
     return [variable]
   where
     variableName = mkName $ camel (T.unpack flowName)
-    dataNameText = flowName <> "_states"
-    initialStateTypeName = mkName . (pascal (T.unpack dataNameText) <>) . pascal $ T.unpack (toText initial)
+    initialStateTypeName = mkName . pascal $ T.unpack (toText initial)
 
 genTypesFromChart :: (AsText e, AsText s) => FlowName -> Chart s e -> Q [Dec]
 genTypesFromChart flowName chart = do
@@ -205,8 +202,7 @@ genStateDec flowName state =
         (NormalB $ bodyExp state)
         []
   where
-    dataNameText = flowName <> "_states"
-    stateTypeName_ = mkName . (pascal (T.unpack dataNameText) <>) . pascal $ T.unpack $ toText $ sid state
+    stateTypeName_ = mkName . pascal $ T.unpack $ toText $ sid state
     decName = stateValueName $ toText $ sid state
     onentryExp = ListE . fmap (genContentExp flowName) . onEntry $ state
     onexitExp = ListE . fmap (genContentExp flowName) . onExit $ state
@@ -242,7 +238,7 @@ genStateDec flowName state =
         applyExpression
             [ nameE "MultiState"
             , ConE stateTypeName_
-            , nameE . (pascal (T.unpack dataNameText) <>) . pascal . T.unpack . toText $ msInitial
+            , nameE . pascal . T.unpack . toText $ msInitial
             , ListE $ VarE . stateValueName . toText . Types.sid <$> subStates -- sid
             , ListE $ genTransitionExp flowName (toText sid) <$> transitions
             , LitE . StringL . T.unpack $ description


### PR DESCRIPTION
E.g.
```haskell
data InvoiceFlowStates
    = InvoiceFlowStatesSettling
    | InvoiceFlowStatesDebtCollection
```

becomes

```haskell
data InvoiceFlowStates
    = Settling
    | DebtCollection
```

This does introduce a risk of state and event names colliding. Is this an acceptable risk?